### PR TITLE
Add disablePreventScroll ={false} prop to ComboBox Drawer

### DIFF
--- a/components/combobox/combobox.tsx
+++ b/components/combobox/combobox.tsx
@@ -170,7 +170,7 @@ export default function ComboBox({
 							</PopoverContent>
 						</Popover>
 					) : (
-						<Drawer open={open} onOpenChange={setOpen}>
+						<Drawer open={open} onOpenChange={setOpen} disablePreventScroll={false}>
 							<DrawerTrigger asChild>
 								<FormControl>
 									<Button


### PR DESCRIPTION
## 연관 Issue
#66 

## 설명
- 이 커밋은 `Drawer`컴포넌트의 `disablePreventScroll` props를 `false`로 설정합니다.

## 목적
- 예기치 않은 스크롤 이벤트가 일어나지 않도록 합니다.